### PR TITLE
Feature: Disable Suggested Video

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -78,7 +78,10 @@ jobs:
       - name: Download iOS 16.2 SDK
         if: steps.SDK.outputs.cache-hit != 'true'
         run: |
-          svn checkout -q https://github.com/arichorn/sdks/trunk/iPhoneOS16.2.sdk
+          git clone -n --depth=1 --filter=tree:0 https://github.com/arichorn/sdks/
+          cd sdks
+          git sparse-checkout set --no-cone iPhoneOS16.2.sdk
+          git checkout
           mv *.sdk $THEOS/sdks
         env:
           THEOS: ${{ github.workspace }}/theos

--- a/Source/Settings.xm
+++ b/Source/Settings.xm
@@ -107,6 +107,16 @@ extern NSBundle *YTLitePlusBundle();
                 }
                 settingItemId:0],
 
+            [YTSettingsSectionItemClass switchItemWithTitle:LOC(@"NO_SUGGESTED_VIDEO")
+                titleDescription:LOC(@"NO_SUGGESTED_VIDEO_DESC")
+                accessibilityIdentifier:nil
+                switchOn:IsEnabled(@"noSuggestedVideo_enabled")
+                switchBlock:^BOOL (YTSettingsCell *cell, BOOL enabled) {
+                    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:@"noSuggestedVideo_enabled"];
+                    return YES;
+                }
+                settingItemId:0],
+
             [YTSettingsSectionItemClass switchItemWithTitle:LOC(@"HIDE_HEATWAVES")
                 titleDescription:LOC(@"HIDE_HEATWAVES_DESC")
                 accessibilityIdentifier:nil

--- a/YTLitePlus.xm
+++ b/YTLitePlus.xm
@@ -351,6 +351,16 @@ static BOOL IsEnabled(NSString *key) {
 }
 %end
 
+// YTNoSuggestedVideo - https://github.com/bhackel/YTNoSuggestedVideo
+%hook YTMainAppVideoPlayerOverlayViewController
+- (bool)shouldShowAutonavEndscreen {
+    if (IsEnabled(@"noSuggestedVideo_enabled")) {
+        return false;
+    }
+    return %orig;
+}
+%end
+
 // BigYTMiniPlayer: https://github.com/Galactic-Dev/BigYTMiniPlayer
 %group Main
 %hook YTWatchMiniBarView

--- a/lang/YTLitePlus.bundle/ar.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ar.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "HIDE_RIGHT_PANEL" = "إخفاء اللوحة اليمنى في وضع ملء الشاشة";
 "HIDE_RIGHT_PANEL_DESC" = "مطلوب إعادة تشغيل التطبيق";
 
+"NO_SUGGESTED_VIDEO" = "Hide Suggested Video (YTNoSuggestedVideo)";
+"NO_SUGGESTED_VIDEO_DESC" = "Remove the suggested video popup when finishing a video";
+
 "HIDE_HEATWAVES" = "إخفاء موجات الحر";
 "HIDE_HEATWAVES_DESC" = "يخفي موجات الحر في مشغل الفيديو. مطلوب إعادة تشغيل التطبيق.";
 

--- a/lang/YTLitePlus.bundle/en.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/en.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "HIDE_RIGHT_PANEL" = "Hide the right panel in fullscreen mode";
 "HIDE_RIGHT_PANEL_DESC" = "App restart is required.";
 
+"NO_SUGGESTED_VIDEO" = "Hide Suggested Video (YTNoSuggestedVideo)";
+"NO_SUGGESTED_VIDEO_DESC" = "Remove the suggested video popup when finishing a video";
+
 "HIDE_HEATWAVES" = "Hide Heatwaves";
 "HIDE_HEATWAVES_DESC" = "Hides the Heatwaves in the video player. App restart is required.";
 

--- a/lang/YTLitePlus.bundle/es.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/es.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "HIDE_RIGHT_PANEL" = "Ocultar el panel derecho en modo pantalla completa";
 "HIDE_RIGHT_PANEL_DESC" = "Es necesario reiniciar la aplicación.";
 
+"NO_SUGGESTED_VIDEO" = "Hide Suggested Video (YTNoSuggestedVideo)";
+"NO_SUGGESTED_VIDEO_DESC" = "Remove the suggested video popup when finishing a video";
+
 "HIDE_HEATWAVES" = "Ocultar Heatwaves";
 "HIDE_HEATWAVES_DESC" = "Oculta las Heatwaves en el reproductor de vídeo. Es necesario reiniciar la aplicación.";
 

--- a/lang/YTLitePlus.bundle/fr.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/fr.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "HIDE_RIGHT_PANEL" = "Masquer le panneau de droite en mode plein écran";
 "HIDE_RIGHT_PANEL_DESC" = "Le redémarrage de l'application est requis.";
 
+"NO_SUGGESTED_VIDEO" = "Hide Suggested Video (YTNoSuggestedVideo)";
+"NO_SUGGESTED_VIDEO_DESC" = "Remove the suggested video popup when finishing a video";
+
 "HIDE_HEATWAVES" = "Masquer les Heatwaves";
 "HIDE_HEATWAVES_DESC" = "Masque les Heatwaves dans le lecteur vidéo. Le redémarrage de l'application est requis.";
 

--- a/lang/YTLitePlus.bundle/ja.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ja.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "HIDE_RIGHT_PANEL" = "フルスクリーンモードで右パネルを非表示";
 "HIDE_RIGHT_PANEL_DESC" = "アプリの再起動が必要です。";
 
+"NO_SUGGESTED_VIDEO" = "Hide Suggested Video (YTNoSuggestedVideo)";
+"NO_SUGGESTED_VIDEO_DESC" = "Remove the suggested video popup when finishing a video";
+
 "HIDE_HEATWAVES" = "ヒートウェーブを非表示";
 "HIDE_HEATWAVES_DESC" = "動画プレーヤーのヒートウェーブを非表示にします。アプリの再起動が必要です。";
 

--- a/lang/YTLitePlus.bundle/pt.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/pt.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "HIDE_RIGHT_PANEL" = "Hide the right panel in fullscreen mode";
 "HIDE_RIGHT_PANEL_DESC" = "App restart is required.";
 
+"NO_SUGGESTED_VIDEO" = "Hide Suggested Video (YTNoSuggestedVideo)";
+"NO_SUGGESTED_VIDEO_DESC" = "Remove the suggested video popup when finishing a video";
+
 "HIDE_HEATWAVES" = "Hide Heatwaves";
 "HIDE_HEATWAVES_DESC" = "Hides the Heatwaves in the video player. App restart is required.";
 

--- a/lang/YTLitePlus.bundle/ro.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ro.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "HIDE_RIGHT_PANEL" = "Ascunde panoul lateral în modul ecran complet";
 "HIDE_RIGHT_PANEL_DESC" = "Este necesară repornirea aplicației.";
 
+"NO_SUGGESTED_VIDEO" = "Hide Suggested Video (YTNoSuggestedVideo)";
+"NO_SUGGESTED_VIDEO_DESC" = "Remove the suggested video popup when finishing a video";
+
 "HIDE_HEATWAVES" = "Ascunde Heatwaves";
 "HIDE_HEATWAVES_DESC" = "Ascundere Heatwaves în player-ul video. Este necesară repornirea aplicației.";
 

--- a/lang/YTLitePlus.bundle/ru.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ru.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "HIDE_RIGHT_PANEL" = "Hide the right panel in fullscreen mode";
 "HIDE_RIGHT_PANEL_DESC" = "App restart is required.";
 
+"NO_SUGGESTED_VIDEO" = "Hide Suggested Video (YTNoSuggestedVideo)";
+"NO_SUGGESTED_VIDEO_DESC" = "Remove the suggested video popup when finishing a video";
+
 "HIDE_HEATWAVES" = "Hide Heatwaves";
 "HIDE_HEATWAVES_DESC" = "Hides the Heatwaves in the video player. App restart is required.";
 

--- a/lang/YTLitePlus.bundle/template.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/template.lproj/Localizable.strings
@@ -32,6 +32,9 @@ https://github.com/PoomSmart/Return-YouTube-Dislikes/tree/main/layout/Library/Ap
 "HIDE_RIGHT_PANEL" = "Hide the right panel in fullscreen mode";
 "HIDE_RIGHT_PANEL_DESC" = "App restart is required.";
 
+"NO_SUGGESTED_VIDEO" = "Hide Suggested Video (YTNoSuggestedVideo)";
+"NO_SUGGESTED_VIDEO_DESC" = "Remove the suggested video popup when finishing a video";
+
 "HIDE_HEATWAVES" = "Hide Heatwaves";
 "HIDE_HEATWAVES_DESC" = "Hides the Heatwaves in the video player. App restart is required.";
 

--- a/lang/YTLitePlus.bundle/tr.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/tr.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "HIDE_RIGHT_PANEL" = "Hide the right panel in fullscreen mode";
 "HIDE_RIGHT_PANEL_DESC" = "App restart is required.";
 
+"NO_SUGGESTED_VIDEO" = "Hide Suggested Video (YTNoSuggestedVideo)";
+"NO_SUGGESTED_VIDEO_DESC" = "Remove the suggested video popup when finishing a video";
+
 "HIDE_HEATWAVES" = "Hide Heatwaves";
 "HIDE_HEATWAVES_DESC" = "Hides the Heatwaves in the video player. App restart is required.";
 

--- a/lang/YTLitePlus.bundle/vi.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/vi.lproj/Localizable.strings
@@ -29,6 +29,9 @@
 "DONT_EAT_MY_CONTENT" = "Ngăn Notch/Đảo trên nội dung video 2:1 (DontEatMyContent)";
 "DONT_EAT_MY_CONTENT_DESC" = "Ngăn notch/Dynamic Island nghiền ngẫm nội dung video 2:1 trên YouTube. Khởi động lại ứng dụng là bắt buộc.";
 
+"NO_SUGGESTED_VIDEO" = "Hide Suggested Video (YTNoSuggestedVideo)";
+"NO_SUGGESTED_VIDEO_DESC" = "Remove the suggested video popup when finishing a video";
+
 "HIDE_HEATWAVES" = "Ẩn sóng nhiệt";
 "HIDE_HEATWAVES_DESC" = "Ẩn Sóng nhiệt trong trình phát video. Khởi động lại ứng dụng là bắt buộc.";
 


### PR DESCRIPTION
This update implements a small tweak I wrote to remove the suggested video popup that appears whenever a video finishes. The toggle for the tweak is in Youtube Settings -> YTLitePlus -> Video Controls Overlay Options.

This update also implements a workflow fix caused by the removal of subversion support in GitHub. The relevant links are a [stackoverflow post](https://stackoverflow.com/questions/600079/how-do-i-clone-a-subdirectory-only-of-a-git-repository/52269934#52269934) and a [GitHub post](https://github.blog/2023-01-20-sunsetting-subversion-support/) describing the removal of subversion.

My concern is with the localization, I simply wrote the messages in English, but I could translate them using some translator if that makes sense.