### PR TITLE
Enable parallel-building for: Fix Compilling & Build Package phase by using newer make

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -65,7 +65,10 @@ jobs:
           (echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bash_profile)
           cat ~/.bash_profile
           whereis make
-          make
+          whereis gmake
+          make --version
+          export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
+          make --version
 
       - name: Setup Theos
         uses: actions/checkout@v3.5.3

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -60,16 +60,6 @@ jobs:
       - name: Install Dependencies
         run: brew install ldid dpkg make
 
-      - name: Do the echo part beforehand
-        run: |
-          (echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bash_profile)
-          cat ~/.bash_profile
-          whereis make
-          whereis gmake
-          make --version
-          export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
-          make --version
-
       - name: Setup Theos
         uses: actions/checkout@v3.5.3
         with:
@@ -130,8 +120,9 @@ jobs:
       - name: Fix Compiling & Build Package
         id: build_package
         run: |
-          #(echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bash_profile)
+          (echo export PATH="/usr/local/opt/make/libexec/gnubin:$PATH" >> ~/.bash_profile)
           source ~/.bash_profile
+          make --version
           cd ${{ github.workspace }}/main
           sed -i '' "12s#.*#BUNDLE_ID = ${{ env.BUNDLE_ID }}#g" Makefile
           sed -i '' "11s#.*#DISPLAY_NAME = ${{ env.APP_NAME }}#g" Makefile

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -54,8 +54,8 @@ jobs:
         with:
           path: main
           submodules: recursive
-      - name: show what kinda of shells we have
-        run: ls -al ~/
+      - name: show what is inside bashrc
+        run: cat ~/.bashrc
 
       - name: Install Dependencies
         run: brew install ldid dpkg make
@@ -118,12 +118,14 @@ jobs:
           YOUTUBE_URL: ${{ inputs.decrypted_youtube_url }}
 
       - name: Do the echo part beforehand
-        run: (echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.zprofile)
+        run: |
+          (echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bashrc)
+          cat ~/.bashrc
 
       - name: Fix Compiling & Build Package
         id: build_package
         run: |
-          (echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.zprofile)
+          #(echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bashrc)
           cd ${{ github.workspace }}/main
           sed -i '' "12s#.*#BUNDLE_ID = ${{ env.BUNDLE_ID }}#g" Makefile
           sed -i '' "11s#.*#DISPLAY_NAME = ${{ env.APP_NAME }}#g" Makefile

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -119,13 +119,13 @@ jobs:
 
       - name: Do the echo part beforehand
         run: |
-          (echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bashrc)
-          cat ~/.bashrc
+          (echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bash_profile)
+          cat ~/.bash_profile
 
       - name: Fix Compiling & Build Package
         id: build_package
         run: |
-          #(echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bashrc)
+          #(echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bash_profile)
           cd ${{ github.workspace }}/main
           sed -i '' "12s#.*#BUNDLE_ID = ${{ env.BUNDLE_ID }}#g" Makefile
           sed -i '' "11s#.*#DISPLAY_NAME = ${{ env.APP_NAME }}#g" Makefile

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -121,11 +121,14 @@ jobs:
         run: |
           (echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bash_profile)
           cat ~/.bash_profile
+          whereis make
+          make
 
       - name: Fix Compiling & Build Package
         id: build_package
         run: |
           #(echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bash_profile)
+          source ~/.bash_profile
           cd ${{ github.workspace }}/main
           sed -i '' "12s#.*#BUNDLE_ID = ${{ env.BUNDLE_ID }}#g" Makefile
           sed -i '' "11s#.*#DISPLAY_NAME = ${{ env.APP_NAME }}#g" Makefile

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           path: main
           submodules: recursive
+      - name: show what kinda of shells we have
+        run: ls -al
 
       - name: Install Dependencies
         run: brew install ldid dpkg make

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -55,7 +55,7 @@ jobs:
           path: main
           submodules: recursive
       - name: show what kinda of shells we have
-        run: ls -al
+        run: ls -al ~/
 
       - name: Install Dependencies
         run: brew install ldid dpkg make

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -54,8 +54,6 @@ jobs:
         with:
           path: main
           submodules: recursive
-      - name: show what is inside bashrc
-        run: cat ~/.bashrc
 
       - name: Install Dependencies
         run: brew install ldid dpkg make
@@ -122,7 +120,6 @@ jobs:
         run: |
           (echo export PATH="/usr/local/opt/make/libexec/gnubin:$PATH" >> ~/.bash_profile)
           source ~/.bash_profile
-          make --version
           cd ${{ github.workspace }}/main
           sed -i '' "12s#.*#BUNDLE_ID = ${{ env.BUNDLE_ID }}#g" Makefile
           sed -i '' "11s#.*#DISPLAY_NAME = ${{ env.APP_NAME }}#g" Makefile

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -60,6 +60,13 @@ jobs:
       - name: Install Dependencies
         run: brew install ldid dpkg make
 
+      - name: Do the echo part beforehand
+        run: |
+          (echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bash_profile)
+          cat ~/.bash_profile
+          whereis make
+          make
+
       - name: Setup Theos
         uses: actions/checkout@v3.5.3
         with:
@@ -116,13 +123,6 @@ jobs:
           THEOS: ${{ github.workspace }}/theos
           YOUTUBE_VERSION: ${{ inputs.youtube_version }}
           YOUTUBE_URL: ${{ inputs.decrypted_youtube_url }}
-
-      - name: Do the echo part beforehand
-        run: |
-          (echo PATH=\"$(brew --prefix make)/libexec/gnubin:\$PATH\" >> ~/.bash_profile)
-          cat ~/.bash_profile
-          whereis make
-          make
 
       - name: Fix Compiling & Build Package
         id: build_package


### PR DESCRIPTION
While troubleshooting a different issue (which i think i can fix for myself by removing and freshly installing ytliteplus) i noticed this warning:

==> Notice: Build may be slow as Theos isn’t using all available CPU cores on this computer. Consider upgrading GNU Make: https://theos.dev/docs/parallel-building

I did notice the steps were taken already to use the newer make but it didn't seem to catch up on this.
Looking into it, it seems that ~/.zprofile was being editted but the ci/cd uses ~/.bash_profile. I fixed the way how to export and immediatly source it so it can be done in the same step.

The ipa did come out as expected but i haven't tested the ipa yet myself.

I assume this is the right place to send the PR to, do let me know what you think of this, next PR might be that i update the gh actions as some are a bit older.